### PR TITLE
Clarify arch is the builder and pull go ver from runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 CMDPACKAGE=github.com/quarkslab/kdigger/commands
 VERSION=$$(git describe --tags 2>/dev/null || echo dev)
 GITCOMMIT=$$(git rev-parse HEAD)
-GOVERSION=$$(go version | awk '{print $$3}')
-ARCH=$$(uname -m)
+BUILDERARCH=$$(uname -m)
 
 OUTPUTNAME=kdigger
 
@@ -20,8 +19,7 @@ GOARCH=amd64
 LDFLAGS="-s -w                               \
 	-X $(CMDPACKAGE).VERSION=$(VERSION)      \
 	-X $(CMDPACKAGE).GITCOMMIT=$(GITCOMMIT)  \
-	-X $(CMDPACKAGE).GOVERSION=$(GOVERSION)  \
-	-X $(CMDPACKAGE).ARCH=$(ARCH)"
+	-X $(CMDPACKAGE).BUILDERARCH=$(BUILDERARCH)"
 
 # if CGO_ENABLED=1, the binary will be dynamically linked, and surprisingly,
 # bigger! It seems that it is because of the net package that Go is dynamically

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"runtime"
+
 	"github.com/quarkslab/kdigger/pkg/bucket"
 	"github.com/spf13/cobra"
 )
@@ -11,11 +13,8 @@ var VERSION string
 // GITCOMMIT indicates which git hash the binary was built off of
 var GITCOMMIT string
 
-// GOVERSION indicates the golang version the binary was built with
-var GOVERSION string
-
-// ARCH indicates the arch the binary was built on
-var ARCH string
+// BUILDERARCH indicates the arch the binary was built on
+var BUILDERARCH string
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
@@ -26,8 +25,8 @@ var versionCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// leveraging bucket results to print even if it's not a plugin
 		res := bucket.NewResults("Version")
-		res.SetHeaders([]string{"tag", "gitCommit", "goVersion", "architecture"})
-		res.AddContent([]interface{}{VERSION, GITCOMMIT, GOVERSION, ARCH})
+		res.SetHeaders([]string{"tag", "gitCommit", "goVersion", "builderArch"})
+		res.AddContent([]interface{}{VERSION, GITCOMMIT, runtime.Version(), BUILDERARCH})
 
 		showName := false
 		showComment := false


### PR DESCRIPTION

> buildVersion is the Go tree's version string at build time.

https://cs.opensource.google/go/go/+/refs/tags/go1.18.3:src/runtime/extern.go;l=251-266

`uname -m` still needs to be injected by the build host

make it clear the arch is the builder's arch, not the current system's arch
